### PR TITLE
Adding missing childLambda presence check in ClayMan::element

### DIFF
--- a/clayman.cpp
+++ b/clayman.cpp
@@ -67,8 +67,10 @@ Clay_RenderCommandArray ClayMan::endLayout(){
 
 void ClayMan::element(Clay_ElementDeclaration configs, std::function<void()> childLambda) {
     openElement();
-    applyElementConfigs(configs);
-    childLambda();
+    if(childLambda != nullptr){
+        applyElementConfigs(configs);
+        childLambda();
+    }
     closeElement();           
 }
 


### PR DESCRIPTION
Causing a silent crash on missing lambda/function.

Issue #4 

(lines 70 to 73, i don't know how to use git properly so it took my previous commit sorry. I'll accept commentary about that)