### PR TITLE
fix chrono v2 does not exist

### DIFF
--- a/clayman.hpp
+++ b/clayman.hpp
@@ -247,7 +247,7 @@ class ClayMan {
         uint32_t windowWidth;
         uint32_t windowHeight;
         uint32_t framecount = 0;
-        std::chrono::_V2::system_clock::time_point start = std::chrono::high_resolution_clock::now();
+        std::chrono::system_clock::time_point start = std::chrono::high_resolution_clock::now();
 
         static constexpr size_t maxStringArenaSize = 100000; 
 

--- a/clayman.hpp
+++ b/clayman.hpp
@@ -247,7 +247,7 @@ class ClayMan {
         uint32_t windowWidth;
         uint32_t windowHeight;
         uint32_t framecount = 0;
-        std::chrono::system_clock::time_point start = std::chrono::high_resolution_clock::now();
+        std::chrono::high_resolution_clock::time_point start = std::chrono::high_resolution_clock::now();
 
         static constexpr size_t maxStringArenaSize = 100000; 
 


### PR DESCRIPTION
```
clayman.hpp:250:22: error: no member named '_V2' in namespace 'std::chrono'
  250 |         std::chrono::_V2::system_clock::time_point start = std::chrono::high_resolution_clock::now();
      |         ~~~~~~~~~~~~~^
26 warnings and 1 error generated.
```